### PR TITLE
feat: add occupancy_grid_map_launch

### DIFF
--- a/occupancy_grid_map_launch/CMakeLists.txt
+++ b/occupancy_grid_map_launch/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.8)
+project(occupancy_grid_map_launch)
+
+# find dependencies
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package(INSTALL_TO_SHARE
+  launch
+  config
+)

--- a/occupancy_grid_map_launch/config/nvblox/nvblox_base.yaml
+++ b/occupancy_grid_map_launch/config/nvblox/nvblox_base.yaml
@@ -1,0 +1,114 @@
+# See: https://nvidia-isaac-ros.github.io/repositories_and_packages/isaac_ros_nvblox/isaac_ros_nvblox/api/parameters.html
+/**:
+  ros__parameters:
+    # cuda stream setting
+    cuda_stream_type: 1  # 0: cuda default stream, 1: blocking async stream, 2: non blocking async stream, 3: per-thread default stream.
+    # miscellaneous
+    voxel_size: 0.05
+    num_cameras: 1
+    use_tf_transforms: true
+    # mapping_type: "static_tsdf"  # ["static_tsdf", "static_occupancy"]
+    # mapping_type: "static_occupancy"
+    mapping_type: "human_with_static_occupancy"
+    
+    # Parameters governing frequency of different processing steps in the reconstruction pipeline.
+    # Processing happens every n:th tick_period. <=0 means that no processing take place
+    tick_period_ms: 10
+    integrate_depth_rate_hz: 40.0
+    integrate_color_rate_hz: 5.0
+    integrate_lidar_rate_hz: 40.0
+    update_mesh_rate_hz: 5.0
+    update_esdf_rate_hz: 10.0
+    publish_layer_rate_hz: 5.0
+    publish_debug_vis_rate_hz: 2.0
+    decay_tsdf_rate_hz: 5.0
+    decay_dynamic_occupancy_rate_hz: 10.0
+    clear_map_outside_radius_rate_hz: 1.0
+
+    # printing statistics on console
+    print_rates_to_console: false
+    print_timings_to_console: false
+    print_delays_to_console: false
+    print_queue_drops_to_console: false
+    print_statistics_on_console_period_ms: 10000
+
+    # esdf settings
+    esdf_mode: "2d" # ["2d", "3d"]
+    publish_esdf_distance_slice: true
+    # color settings
+    # use_color: true
+    use_color: false
+    # depth settings
+    use_depth: true
+    # lidar settings
+    use_lidar: true
+    lidar_width: 1800
+    lidar_height: 31
+    lidar_min_valid_range_m: 0.1
+    lidar_max_valid_range_m: 50.0
+    use_non_equal_vertical_fov_lidar_params: false
+    # Input queues
+    maximum_input_queue_length: 10
+    # Map clearing settings
+    map_clearing_radius_m: 7.0 # no map clearing if < 0.0
+    map_clearing_frame_id: "base_link"
+    # QoS settings
+    input_qos: "SYSTEM_DEFAULT"
+    # Visualization
+    esdf_slice_bounds_visualization_attachment_frame_id: "base_link"
+    esdf_slice_bounds_visualization_side_length: 10.0
+    workspace_height_bounds_visualization_attachment_frame_id: "base_link"
+    workspace_height_bounds_visualization_side_length: 10.0
+    layer_visualization_min_tsdf_weight: 0.1
+    layer_visualization_exclusion_height_m: 2.0
+    layer_visualization_exclusion_radius_m: 7.0
+    layer_visualization_undo_gamma_correction: false
+    max_back_projection_distance: 7.0
+    back_projection_subsampling: 1 # no subsampling if == 1
+    layer_streamer_bandwidth_limit_mbps: -1.0 # unlimited
+
+    multi_mapper:
+      connected_mask_component_size_threshold: 2000
+      remove_small_connected_components: true
+
+    static_mapper:
+      # mapper
+      do_depth_preprocessing: false
+      depth_preprocessing_num_dilations: 3
+      # projective integrator (tsdf/color/occupancy)
+      projective_integrator_max_integration_distance_m: 5.0
+      projective_integrator_truncation_distance_vox: 4.0
+      projective_integrator_weighting_mode: "inverse_square_tsdf_distance_penalty"
+      projective_integrator_max_weight: 5.0
+      projective_tsdf_integrator_invalid_depth_decay_factor: -1.0
+      # occupancy integrator
+      free_region_occupancy_probability: 0.45
+      occupied_region_occupancy_probability: 0.55
+      unobserved_region_occupancy_probability: 0.5
+      occupied_region_half_width_m: 0.1
+      # view calculator
+      raycast_subsampling_factor: 4
+      workspace_bounds_type: "unbounded" # ["unbounded", "height_bounds", "bounding_box"]
+      workspace_bounds_min_corner_x_m: 0.0
+      workspace_bounds_min_corner_y_m: 0.0
+      workspace_bounds_min_height_m: -0.5
+      workspace_bounds_max_corner_x_m: 0.0
+      workspace_bounds_max_corner_y_m: 0.0
+      workspace_bounds_max_height_m: 2.0
+      # esdf integrator
+      esdf_integrator_min_weight: 0.1
+      esdf_integrator_max_site_distance_vox: 2.0
+      esdf_integrator_max_distance_m: 2.0
+      # mesh integrator
+      mesh_integrator_min_weight: 0.1
+      mesh_integrator_weld_vertices: true
+      # tsdf decay integrator
+      tsdf_decay_factor: 0.95
+      tsdf_decayed_weight_threshold: 0.001
+      exclude_last_view_from_decay: true
+      tsdf_set_free_distance_on_decayed: false
+      tsdf_decayed_free_distance_vox: 4.0
+      decay_integrator_deallocate_decayed_blocks: true
+      # mesh streamer
+      layer_streamer_exclusion_height_m: 2.0
+      layer_streamer_exclusion_radius_m: 7.0

--- a/occupancy_grid_map_launch/config/nvblox/specializations/nvblox_sim.yaml
+++ b/occupancy_grid_map_launch/config/nvblox/specializations/nvblox_sim.yaml
@@ -1,0 +1,33 @@
+/**:
+  ros__parameters:
+    # Lidar settings
+    use_lidar: false
+    # QoS settings
+    input_qos: "DEFAULT" # NOTE(2024.09.20): Needed to for reliable delivery of messages from Isaac Sim.
+    # Map clearing settings
+    map_clearing_radius_m: 15.0 # no map clearing if < 0.0
+    map_clearing_frame_id: "base_link"
+    # Rviz visualization
+    esdf_slice_bounds_visualization_attachment_frame_id: "base_link"
+
+    # Increase visualization distance (due to lidar)
+    layer_visualization_exclusion_radius_m: 15.0
+
+    static_mapper:
+      # lidar integration
+      lidar_projective_integrator_max_integration_distance_m: 10.0
+      # esdf integrator
+      esdf_slice_height: 0.09
+      # esdf_slice_min_height: 0.09
+      # esdf_slice_min_height: 0.125
+      esdf_slice_min_height: 0.3
+      esdf_slice_max_height: 0.65
+      # mesh streamer
+      layer_streamer_exclusion_radius_m: 15.0
+
+    dynamic_mapper:
+      esdf_slice_height: 0.09
+      # esdf_slice_min_height: 0.09
+      # esdf_slice_min_height: 0.125
+      esdf_slice_min_height: 0.3
+      esdf_slice_max_height: 0.65

--- a/occupancy_grid_map_launch/launch/decompression.launch.xml
+++ b/occupancy_grid_map_launch/launch/decompression.launch.xml
@@ -1,0 +1,19 @@
+<launch>
+  <arg name="container_name" default="stereo_container"/>
+
+  <load_composable_node target="$(var container_name)">
+     <composable_node pkg="isaac_ros_h264_decoder"
+                      plugin="nvidia::isaac_ros::h264_decoder::DecoderNode" name="left_decoder">
+       <remap from="image_compressed" to="left/image_compressed"/>
+       <remap from="image_uncompressed" to="left/image_raw"/>
+     </composable_node>
+   </load_composable_node>
+
+   <load_composable_node target="$(var container_name)">
+     <composable_node pkg="isaac_ros_h264_decoder"
+                      plugin="nvidia::isaac_ros::h264_decoder::DecoderNode" name="right_decoder">
+       <remap from="image_compressed" to="right/image_compressed"/>
+       <remap from="image_uncompressed" to="right/image_raw"/>
+     </composable_node>
+  </load_composable_node>
+</launch>

--- a/occupancy_grid_map_launch/launch/people_semantic_segmentation.launch.xml
+++ b/occupancy_grid_map_launch/launch/people_semantic_segmentation.launch.xml
@@ -1,0 +1,94 @@
+<launch>
+  <arg name="container_name" default="stereo_container"/>
+  <arg name="input_camera_namespace" default=""/>
+
+  <!-- People Segmentation -->
+  <group>
+    <push-ros-namespace namespace="unet"/>
+
+    <!-- Network parameter -->
+    <let name="network_input_width" value="960"/>
+    <let name="network_input_height" value="544"/>
+
+    <!-- TensorRTNode parameters -->
+    <let name="segment_onnx_file_path" value="$(env ISAAC_ROS_WS)/isaac_ros_assets/models/peoplesemsegnet/deployable_quantized_vanilla_unet_onnx_v2.0/model.onnx"/>
+    <let name="segment_engine_file_path" value="$(env ISAAC_ROS_WS)/isaac_ros_assets/models/peoplesemsegnet/deployable_quantized_vanilla_unet_onnx_v2.0/1/model.plan"/>
+    <let name="input_tensor_names" value="[input_tensor]"/>
+    <let name="input_binding_names" value="[input_1:0]"/>
+    <let name="input_tensor_formats" value="['nitros_tensor_list_nchw_bgr_f32']"/>
+    <let name="output_tensor_names" value="[output_tensor]"/>
+    <let name="output_binding_names" value="[argmax_1]"/>
+    <let name="output_tensor_formats" value="['nitros_tensor_list_nhwc_bgr_f32']"/>
+
+    <!-- UNetDecoderNode parameters -->
+    <let name="network_output_type" value="argmax"/>
+    <let name="color_segmentation_mask_encoding" value="bgr8"/>
+    <let name="mask_width" value="960"/>
+    <let name="mask_height" value="544"/>
+
+    <load_composable_node target="$(var container_name)">
+      <!-- resize to the network input -->
+      <composable_node pkg="isaac_ros_image_proc"
+                       plugin="nvidia::isaac_ros::image_proc::ResizeNode" name="unet_resize">
+        <param name="output_width" value="$(var network_input_width)"/>
+        <param name="output_height" value="$(var network_input_height)"/>
+        <remap from="image" to="$(var input_camera_namespace)/image_rect"/>
+        <remap from="camera_info" to="$(var input_camera_namespace)/camera_info_rect"/>
+        <remap from="resize/image" to="image_resize"/>
+        <remap from="resize/camera_info" to="camera_info_resize"/>
+      </composable_node>
+
+      <!-- convert image to tensor -->
+      <composable_node pkg="isaac_ros_tensor_proc"
+                       plugin="nvidia::isaac_ros::dnn_inference::ImageToTensorNode" name="image_to_tensor">
+        <param name="scale" value="True"/>
+        <param name="tensor_name" value="image"/>
+        <remap from="image" to="image_resize"/>
+        <remap from="tensor" to="image_tensor"/>
+      </composable_node>
+
+      <!-- normalize tensor -->
+      <composable_node pkg="isaac_ros_tensor_proc"
+                       plugin="nvidia::isaac_ros::dnn_inference::ImageTensorNormalizeNode" name="normalize">
+        <param name="mean" value="[0.5, 0.5, 0.5]"/>
+        <param name="stddev" value="[0.5, 0.5, 0.5]"/>
+        <param name="input_tensor_name" value="image"/>
+        <param name="output_tensor_name" value="input_tensor"/>
+        <remap from="tensor" to="image_tensor"/>
+      </composable_node>
+
+      <!-- inteleaved to planar -->
+      <composable_node pkg="isaac_ros_tensor_proc"
+                       plugin="nvidia::isaac_ros::dnn_inference::InterleavedToPlanarNode" name="interleaved_to_planner">
+        <param name="input_tensor_shape" value="[$(var network_input_height), $(var network_input_width), 3]"/>
+        <remap from="interleaved_tensor" to="normalized_tensor"/>
+        <remap from="planar_tensor" to="encoded_tensor"/>
+      </composable_node>
+
+      <!-- Inference -->
+      <composable_node pkg="isaac_ros_tensor_rt"
+                       plugin="nvidia::isaac_ros::dnn_inference::TensorRTNode" name="unet_inference">
+        <param name="model_file_path" value="$(var segment_onnx_file_path)"/>
+        <param name="engine_file_path" value="$(var segment_engine_file_path)"/>
+        <param name="force_engine_update" value="false"/>  <!-- this value is true by default and need to be false to use the pre-generated engine file -->
+        <param name="input_tensor_names" value="$(var input_tensor_names)"/>
+        <param name="input_binding_names" value="$(var input_binding_names)"/>
+        <param name="input_tensor_formats" value="$(var input_tensor_formats)"/>
+        <param name="output_tensor_names" value="$(var output_tensor_names)"/>
+        <param name="output_binding_names" value="$(var output_binding_names)"/>
+        <param name="output_tensor_formats" value="$(var output_tensor_formats)"/>
+        <remap from="tensor_pub" to="encoded_tensor"/>
+      </composable_node>
+
+      <composable_node pkg="isaac_ros_unet"
+                       plugin="nvidia::isaac_ros::unet::UNetDecoderNode" name="unet_decoder">
+        <param name="network_output_type" value="$(var network_output_type)"/>
+        <param name="color_segmentation_mask_encoding" value="$(var color_segmentation_mask_encoding)"/>
+        <param name="mask_width" value="$(var mask_width)"/>
+        <param name="mask_height" value="$(var mask_height)"/>
+        <param name="color_palette"
+               value="[0x556B2F, 0x800000, 0x008080, 0x000080, 0x9ACD32, 0xFF0000, 0xFF8C00, 0xFFD700, 0x00FF00, 0xBA55D3, 0x00FA9A, 0x00FFFF, 0x0000FF, 0xF08080, 0xFF00FF, 0x1E90FF, 0xDDA0DD, 0xFF1493, 0x87CEFA, 0xFFDEAD]"/>
+      </composable_node>
+    </load_composable_node>
+  </group>
+</launch>

--- a/occupancy_grid_map_launch/launch/stereo_depth.launch.xml
+++ b/occupancy_grid_map_launch/launch/stereo_depth.launch.xml
@@ -1,0 +1,98 @@
+<launch>
+  <arg name="ess_model" default="ess" description="['ess', 'light_ess']"/>
+  <arg name="threshold" default="0.4"/>
+  <arg name="container_name" default="stereo_container"/>
+  <arg name="do_slam" default="True"/>
+
+  <let name="ess_engine_file_path" value="$(env ISAAC_ROS_WS)/isaac_ros_assets/models/dnn_stereo_disparity/dnn_stereo_disparity_v4.1.0_onnx/$(var ess_model).engine"/>
+  <let name="resize_width" value="960" if="$(eval '&quot;$(var ess_model)&quot;==&quot;ess&quot;')"/>
+  <let name="resize_height" value="576" if="$(eval '&quot;$(var ess_model)&quot;==&quot;ess&quot;')"/>
+  <let name="resize_width" value="480" if="$(eval '&quot;$(var ess_model)&quot;==&quot;light_ess&quot;')"/>
+  <let name="resize_height" value="288" if="$(eval '&quot;$(var ess_model)&quot;==&quot;light_ess&quot;')"/>
+
+  <!-- left rectify & resize -->
+  <group>
+    <push-ros-namespace namespace="left"/>
+    <load_composable_node target="$(var container_name)">
+      <!-- rectify -->
+      <composable_node pkg="isaac_ros_image_proc"
+                       plugin="nvidia::isaac_ros::image_proc::RectifyNode" name="rectify">
+        <param name="output_width" value="1920"/>
+        <param name="output_height" value="1200"/>
+      </composable_node>
+
+      <!-- resize -->
+      <composable_node pkg="isaac_ros_image_proc"
+                       plugin="nvidia::isaac_ros::image_proc::ResizeNode" name="resize">
+        <param name="output_width" value="$(var resize_width)"/>
+        <param name="output_height" value="$(var resize_height)"/>
+        <remap from="image" to="image_rect"/>
+        <remap from="camera_info" to="camera_info_rect"/>
+        <remap from="resize/image" to="image_resize"/>
+        <remap from="resize/camera_info" to="camera_info_resize"/>
+      </composable_node>
+    </load_composable_node >
+  </group>
+
+  <!-- right rectify & resize -->
+  <group>
+    <push-ros-namespace namespace="right" />
+
+    <load_composable_node target="$(var container_name)">
+      <!-- rectify -->
+      <composable_node pkg="isaac_ros_image_proc"
+                       plugin="nvidia::isaac_ros::image_proc::RectifyNode" name="rectify">
+        <param name="output_width" value="1920"/>
+        <param name="output_height" value="1200"/>
+      </composable_node>
+
+      <!-- resize -->
+      <composable_node pkg="isaac_ros_image_proc"
+                       plugin="nvidia::isaac_ros::image_proc::ResizeNode" name="resize">
+        <param name="output_width" value="$(var resize_width)"/>
+        <param name="output_height" value="$(var resize_height)"/>
+        <remap from="image" to="image_rect"/>
+        <remap from="camera_info" to="camera_info_rect"/>
+        <remap from="resize/image" to="image_resize"/>
+        <remap from="resize/camera_info" to="camera_info_resize"/>
+      </composable_node>
+    </load_composable_node >
+  </group>
+
+  <!-- disparity -->
+  <load_composable_node target="$(var container_name)">
+      <composable_node pkg="isaac_ros_ess"
+                       plugin="nvidia::isaac_ros::dnn_stereo_depth::ESSDisparityNode" name="disparity">
+        <remap from="left/image_rect" to="left/image_resize"/>
+        <remap from="right/image_rect" to="right/image_resize"/>
+        <remap from="left/camera_info" to="left/camera_info_resize"/>
+        <remap from="right/camera_info" to="right/camera_info_resize"/>
+        <remap from="camera_info" to="camera_info_disparity"/>
+        <param name="engine_file_path" value="$(var ess_engine_file_path)"/>
+        <param name="threshold" value="$(var threshold)"/>
+      </composable_node>
+  </load_composable_node >
+
+  <!-- disparity to depth -->
+  <load_composable_node target="$(var container_name)">
+      <composable_node pkg="isaac_ros_stereo_image_proc"
+                       plugin="nvidia::isaac_ros::stereo_image_proc::DisparityToDepthNode" name="disparity_to_depth">
+      </composable_node>
+  </load_composable_node >
+
+  <!-- visual slam -->
+  <group if="$(var do_slam)">
+    <load_composable_node target="$(var container_name)">
+      <composable_node pkg="isaac_ros_visual_slam"
+                       plugin="nvidia::isaac_ros::visual_slam::VisualSlamNode" name="visual_slam">
+        <param name="num_cameras" value="2"/>
+        <param name="rectified_images" value="true"/>
+        <remap from="visual_slam/image_0" to="left/image_rect"/>
+        <remap from="visual_slam/image_1" to="right/image_rect"/>
+        <remap from="visual_slam/camera_info_0" to="left/camera_info_rect"/>
+        <remap from="visual_slam/camera_info_1" to="right/camera_info_rect"/>
+      </composable_node>
+    </load_composable_node >
+  </group>
+
+</launch>

--- a/occupancy_grid_map_launch/launch/surround_ogm.launch.xml
+++ b/occupancy_grid_map_launch/launch/surround_ogm.launch.xml
@@ -1,0 +1,101 @@
+<launch>
+  <arg name="live_sensor" default="True"/>
+  <arg name="ess/threshold" default="0.4"/>
+
+  <let name="common_container_name" value="surround_container"/>
+  <!-- <node pkg="rclcpp_components" exec="component_container_mt" name="$(var common_container_name)" namespace="/"/> -->
+  <node pkg="rclcpp_components" exec="component_container_isolated" name="$(var common_container_name)" namespace="/"/>
+
+  <group>
+    <let name="namespace" value="front_stereo_camera"/>
+    <push-ros-namespace namespace="$(var namespace)"/>
+    <include file="$(find-pkg-share occupancy_grid_map_launch)/launch/decompression.launch.xml" unless="$(var live_sensor)">
+      <arg name="container_name" value="$(var common_container_name)"/>
+    </include>
+    <include file="$(find-pkg-share occupancy_grid_map_launch)/launch/stereo_depth.launch.xml">
+      <arg name="threshold" value="$(var ess/threshold)"/>
+      <arg name="container_name" value="$(var common_container_name)"/>
+      <arg name="do_slam" value="True"/>
+    </include>
+    <include file="$(find-pkg-share occupancy_grid_map_launch)/launch/people_semantic_segmentation.launch.xml">
+      <arg name="container_name" value="$(var common_container_name)"/>
+      <arg name="input_camera_namespace" value="/$(var namespace)/left"/>
+    </include>
+  </group>
+
+  <group>
+    <let name="namespace" value="right_stereo_camera"/>
+    <push-ros-namespace namespace="$(var namespace)"/>
+    <include file="$(find-pkg-share occupancy_grid_map_launch)/launch/decompression.launch.xml" unless="$(var live_sensor)">
+      <arg name="container_name" value="$(var common_container_name)"/>
+    </include>
+    <include file="$(find-pkg-share occupancy_grid_map_launch)/launch/stereo_depth.launch.xml">
+      <arg name="threshold" value="$(var ess/threshold)"/>
+      <arg name="container_name" value="$(var common_container_name)"/>
+      <arg name="do_slam" value="False"/>
+    </include>
+    <include file="$(find-pkg-share occupancy_grid_map_launch)/launch/people_semantic_segmentation.launch.xml">
+      <arg name="container_name" value="$(var common_container_name)"/>
+      <arg name="input_camera_namespace" value="/$(var namespace)/left"/>
+    </include>
+  </group>
+
+  <group>
+    <let name="namespace" value="left_stereo_camera"/>
+    <push-ros-namespace namespace="$(var namespace)"/>
+    <include file="$(find-pkg-share occupancy_grid_map_launch)/launch/decompression.launch.xml" unless="$(var live_sensor)">
+      <arg name="container_name" value="$(var common_container_name)"/>
+    </include>
+    <include file="$(find-pkg-share occupancy_grid_map_launch)/launch/stereo_depth.launch.xml">
+      <arg name="threshold" value="$(var ess/threshold)"/>
+      <arg name="container_name" value="$(var common_container_name)"/>
+      <arg name="do_slam" value="False"/>
+    </include>
+    <include file="$(find-pkg-share occupancy_grid_map_launch)/launch/people_semantic_segmentation.launch.xml">
+      <arg name="container_name" value="$(var common_container_name)"/>
+      <arg name="input_camera_namespace" value="/$(var namespace)/left"/>
+    </include>
+  </group>
+
+
+
+  <!-- run nvblox to get occupancy grid -->
+  <let name="base_config" value="$(find-pkg-share occupancy_grid_map_launch)/config/nvblox/nvblox_base.yaml"/>
+  <let name="camera_config" value="$(find-pkg-share occupancy_grid_map_launch)/config/nvblox/specializations/nvblox_sim.yaml"/>
+  <load_composable_node target="$(var common_container_name)">
+    <composable_node pkg="nvblox_ros"
+                     plugin="nvblox::NvbloxNode" name="nvblox">
+      <!-- load base parameters and overwrite the project specific ones -->
+      <param from="$(var base_config)"/>
+      <param from="$(var camera_config)"/>
+      <param name="num_cameras" value="3"/>
+      <param name="use_lidar" value="False"/>
+      <param name="use_segmentation" value="True"/>
+
+      <!-- camera0: front -->
+      <remap from="camera_0/depth/image" to="/front_stereo_camera/depth"/>
+      <remap from="camera_0/depth/camera_info" to="/front_stereo_camera/camera_info_disparity"/>n
+      <remap from="camera_0/color/image" to="/front_stereo_camera/left/image_raw"/>
+      <remap from="camera_0/color/camera_info" to="/front_stereo_camera/left/camera_info"/>
+      <remap from="camera_0/mask/image" to="/front_stereo_camera/unet/unet/raw_segmentation_mask"/>
+      <remap from="camera_0/mask/camera_info" to="/front_stereo_camera/unet/camera_info_resize"/>
+      <!-- camera1: left -->
+      <remap from="camera_1/depth/image" to="/left_stereo_camera/depth"/>
+      <remap from="camera_1/depth/camera_info" to="/left_stereo_camera/camera_info_disparity"/>
+      <remap from="camera_1/color/image" to="/left_stereo_camera/left/image_raw"/>
+      <remap from="camera_1/color/camera_info" to="/left_stereo_camera/left/camera_info"/>
+      <remap from="camera_1/mask/image" to="/left_stereo_camera/unet/unet/raw_segmentation_mask"/>
+      <remap from="camera_1/mask/camera_info" to="/left_stereo_camera/unet/camera_info_resize"/>
+      <!-- camera2: right -->
+      <remap from="camera_2/depth/image" to="/right_stereo_camera/depth"/>
+      <remap from="camera_2/depth/camera_info" to="/right_stereo_camera/camera_info_disparity"/>
+      <remap from="camera_2/color/image" to="/right_stereo_camera/left/image_raw"/>
+      <remap from="camera_2/color/camera_info" to="/right_stereo_camera/left/camera_info"/>
+      <remap from="camera_2/mask/image" to="/right_stereo_camera/unet/unet/raw_segmentation_mask"/>
+      <remap from="camera_2/mask/camera_info" to="/right_stereo_camera/unet/camera_info_resize"/>
+      <!-- other parameters -->
+      <remap from="pose" to="/front_stereo_camera/vo_pose"/>
+    </composable_node>
+  </load_composable_node >
+
+</launch>

--- a/occupancy_grid_map_launch/package.xml
+++ b/occupancy_grid_map_launch/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>occupancy_grid_map_launch</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="manato.hirabayashi@tier4.jp">manatohirabayashi</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <exec_depend>isaac_ros_h264_decoder</exec_depend>
+  <exec_depend>isaac_ros_image_proc</exec_depend>
+  <exec_depend>isaac_ros_ess</exec_depend>
+  <exec_depend>isaac_ros_stereo_image_proc</exec_depend>
+  <exec_depend>isaac_ros_visual_slam</exec_depend>
+  <exec_depend>isaac_ros_tensor_proc</exec_depend>
+  <exec_depend>isaac_ros_tensor_rt</exec_depend>
+  <exec_depend>isaac_ros_unet</exec_depend>
+  <exec_depend>nvblox_ros</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This PR adds a package to generate vision-based occupancy grid maps.

I confirmed this package by the following procedures:

```shell
$ colcon build --symlink-install --cmake-args  -DCMAKE_BUILD_TYPE=Release --packages-up-to occupancy_grid_map_launch
$ ros2 launch occupancy_grid_map_launch surround_ogm.launch.xml live_sensor:=false
```
(Since I tested using recorded data, I added `live_sensor:=false` option to boot the data decompressor. This option does not need to be added to the execution on the actual vehicle)
![Screenshot from 2025-02-25 10-53-36](https://github.com/user-attachments/assets/5d94ff1b-7002-478b-9a77-6116afd04b8a)

### Note
Currently, generated occupancy grid maps only detect obstacles with a height of 0.3 [m] -- 0.65 [m] from the ground. To detect low-height (such as 15[cm]) objects, we need to tune parameters/configurations further.

### related issue
- https://github.com/tier4/autoware_nova_carter/issues/17